### PR TITLE
Default to GitHub Actions integration ID when app_id is null

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ function convertBranchProtectionToRuleset(branchProtection) {
         required_status_checks:
           branchProtection.required_status_checks.checks.map((check) => ({
             context: check.context,
-            integration_id: check.app_id,
+            integration_id: check.app_id || 15368,
           })),
       },
     };


### PR DESCRIPTION
On some repositories the current branch protections are returning null for the app_id, possibly because the checks have not run recently.

For now we can default to the GHA integration ID and fix it later if there is a mismatch and the check is from another source.

Change-type: patch