### PR TITLE
Do not set integration id when converting to rulesets

### DIFF
--- a/assets/settings.yml
+++ b/assets/settings.yml
@@ -7,11 +7,12 @@ repository:
   allow_auto_merge: true
   delete_branch_on_merge: true
 
-# disable branch protection for default branch
-# and use rulesets to enforce policies
-branches:
-  - name: default
-    protection: null
+# TODO:
+# # disable branch protection for default branch
+# # and use rulesets to enforce policies
+# branches:
+#   - name: default
+#     protection: null
 
 # rulesets can have exceptions for flowzone-app to bypass policies
 # https://github.com/github/safe-settings/blob/main-enterprise/docs/sample-settings/org-ruleset.yml

--- a/index.js
+++ b/index.js
@@ -224,7 +224,6 @@ function protectionDataToRuleset(protectionData) {
         required_status_checks:
           protectionData.required_status_checks.checks.map((check) => ({
             context: check.context,
-            ...(check.app_id ? { integration_id: check.app_id } : {}),
           })),
       },
     };


### PR DESCRIPTION
If the integration id is a GHA and it hasn't run recently, the ruleset will fail to be applied.

Change-type: patch